### PR TITLE
fix issue with not being able actually access download url / download…

### DIFF
--- a/includes/class-plugin-updater.php
+++ b/includes/class-plugin-updater.php
@@ -167,7 +167,7 @@ class ExamplePluginUpdater {
 			&& version_compare( $this->version, $remote->update->version, '<' )
 		) {
 			$res->new_version = $remote->update->version;
-			$res->package     = $remote->update->download_url;
+			$res->package     = $remote->update->download_link;
 
 			$transient->response[ $res->plugin ] = $res;
 		} else {


### PR DESCRIPTION
In the class-plugin-updater.php file I kept getting an error about an "Undefined property: stdClass::$download_url" looks like what is returned was changed to download_link instead of download_url, so I've just updated the property here.